### PR TITLE
fix(ci): make sure to generateUsage help files before triggering build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,9 @@ jobs:
         run: |
           echo "$(./gradlew changelogPrintLatestVersionContent -Prelease=true -PreleaseForceVersion=${{ github.event.inputs.force_version }} --quiet)" > "app/build/release-notes.md"
       - name: "Create release"
-        run: "./gradlew -Prelease=true -PreleaseForceVersion=${{ github.event.inputs.force_version }} -PreleaseBinariesRootDir=app/build/collected-binaries changelogPush"
+        run: |
+          ./gradlew generateUsage
+          ./gradlew -Prelease=true -PreleaseForceVersion=${{ github.event.inputs.force_version }} -PreleaseBinariesRootDir=app/build/collected-binaries changelogPush
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for gh cli usage
       - name: "Get version and set to output"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Adapted the build so that README.md does correctly include usage helps when updated during the release process
+
 ### Added
 
 - Commit, tag and push the choco source files to the chocolatey-bucket repository during the release process


### PR DESCRIPTION
this makes sure that when README.md is updated with latest version number(s), there is also an up-to-date collection of usage help files available. This is required, because even when using a dependency to `generateUsage` task, the config phase of spotlessMarkdownApply has already picked up the empty/non-existing files, even though they would be available when the task is actually run...
so by generating the files before hand, we make sure they are available in config phase of spotlessMarkdownApply.